### PR TITLE
fill-column-indicator: add vertical bar face

### DIFF
--- a/doom-moonfly-theme.el
+++ b/doom-moonfly-theme.el
@@ -234,7 +234,7 @@ Can be an integer to determine the exact padding."
    (rainbow-delimiters-depth-7-face :foreground bright-blue)
    (rainbow-delimiters-depth-8-face :foreground bright-green)
    (rainbow-delimiters-depth-9-face :foreground cyan)
-    ;;;; treemacs
+   ;;;; treemacs
    (treemacs-directory-face     :foreground base8)
    (treemacs-file-face          :foreground fg)
    (treemacs-git-added-face     :foreground bright-green)
@@ -303,7 +303,9 @@ Can be an integer to determine the exact padding."
    (magit-section-heading-selection :foreground bright-blue :weight 'bold)
    (magit-section-highlight         :weight 'bold)
    (magit-section-title             :background bg :foreground bright-purple :weight 'bold)
-   (magit-tag :background bg :foreground bright-cyan :box 't))
+   (magit-tag :background bg :foreground bright-cyan :box 't)
+   ;;;; display-fill-column-indicator-mode
+   (fill-column-indicator :height 1 :background vertical-bar :foreground vertical-bar ))
   ;;;; Base theme variable overrides-
   ())
 


### PR DESCRIPTION
This change is taken from
modus-themes (https://www.gnu.org/software/emacs/manual/html_node/modus-themes/Note-on-display_002dfill_002dcolumn_002dindicator_002dmode.html): The display-fill-column-indicator-mode uses a typographic character to draw its line. This has the downside of creating a dashed line. The dashes are further apart depending on how tall the font’s glyph height is and what integer the line-spacing is set to.

At the theme level we eliminate this effect by making the character one pixel tall: the line is contiguous.

PS: Thanks for porting this beautiful theme, I use it every day <3